### PR TITLE
Add Test Workflow for Exit on Failure

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Test exiting on failure
+
+on: [push]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Try to fail
+      run: exit 1
+    - name: Print message if we don't fail
+      run: echo Should not get here


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
This PR introduces a new GitHub Actions workflow that tests the behavior of the system when a failure occurs. The main points of this PR are:
- A new workflow is added to the GitHub Actions, which is triggered on every push.
- The workflow runs on three different operating systems: Ubuntu, Windows, and macOS.
- The workflow is designed to fail intentionally and then print a message if it doesn't fail.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/main.yml`: Added a new GitHub Actions workflow named 'Test exiting on failure'. This workflow is triggered on every push and runs on three different operating systems. It includes two steps: one that intentionally fails, and another one that prints a message if the previous step doesn't fail.
</details>
