### PR TITLE
Add GitHub Action Workflow to Test Failure Exit Code Handling

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Test exiting on failure
+
+on: [push]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Try to fail
+      run: exit 1
+    - name: Print message if we don't fail
+      run: echo Should not get here


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduced a new GitHub Action workflow to test the behavior when a job fails.
- The workflow is triggered on push events.
- It includes a job that runs on three different operating systems (Ubuntu, Windows, macOS).
- The job consists of steps that check out the code, intentionally fail the process, and print a message if the failure is not handled correctly.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/main.yml`: - Added a new workflow named 'Test exiting on failure' that is triggered on push events.
- Defined a job 'build' with a strategy to run on multiple operating systems.
- Included steps to checkout the repository, intentionally exit with a failure code, and print a message if the failure is not caught.
</details>
