### PR TITLE
Implement GitHub Action Workflow to Fail on First Error

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Test exiting on failure
+
+on: [push]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Try to fail
+      run: exit 1
+    - name: Print message if we don't fail
+      run: echo Should not get here


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Added a new GitHub Actions workflow that is designed to fail on the first error encountered.
- The workflow is triggered on every push event.
- It includes a job that runs on three different operating systems: Ubuntu, Windows, and macOS.
- The job consists of steps that check out the code, deliberately fail to test the exit on failure behavior, and a step that should not execute if the failure step works correctly.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/main.yml`: Added a new workflow named 'Test exiting on failure' that triggers on push events. It includes a 'build' job that runs on the latest versions of Ubuntu, Windows, and macOS. The job has steps to checkout the code, intentionally exit with a failure, and a subsequent step that prints a message which should not execute if the previous step fails as intended.
</details>
