### PR TITLE
Add GitHub Action Workflow to Test Failure Exit Code

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Test exiting on failure
+
+on: [push]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Try to fail
+      run: exit 1
+    - name: Print message if we don't fail
+      run: echo Should not get here


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a new GitHub Actions workflow named "Test exiting on failure".
- The workflow is triggered on push events.
- Defines a job named "build" that runs across three different operating systems: ubuntu-latest, windows-latest, and macOS-latest.
- The "build" job consists of three steps:
  - Checkout the repository using actions/checkout@v1.
  - A step designed to fail by exiting with code 1.
  - A step that prints a message, which should not execute due to the previous step's failure.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/main.yml`: Added a new workflow that tests the CI system's ability to exit upon a failure. The workflow runs a job on the latest versions of Ubuntu, Windows, and macOS, with steps to checkout the code, deliberately fail the build, and a post-failure step that should not run.
</details>
