### PR TITLE
Create fail job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Test exiting on failure
+
+on: [push]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Try to fail
+      run: exit 1
+    - name: Print message if we don't fail
+      run: echo Should not get here


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduced a new GitHub Actions workflow named "Test exiting on failure".
- The workflow is triggered on push events.
- Defines a job named 'build' that runs on the latest versions of Ubuntu, Windows, and macOS.
- The 'build' job consists of steps that check out the code and then deliberately fail to test the exit code handling.
- Includes a step that should not execute, serving as a check to ensure the job fails as expected.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/main.yml`: Added a new workflow that tests the CI system's ability to exit upon a failure. The workflow runs a job on three different operating systems and includes steps to checkout the repository, intentionally fail the build, and a post-failure step that should not run, indicating correct behavior if it does not execute.
</details>
