### PR TITLE
Create fail job 1213123

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,18 @@
+name: Test exiting on failure
+
+on: [push]
+
+jobs:
+  build:
+
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest, macOS-latest]
+    runs-on: ${{ matrix.os }}
+    
+    steps:
+    - uses: actions/checkout@v1
+    - name: Try to fail
+      run: exit 1
+    - name: Print message if we don't fail
+      run: echo Should not get here


### PR DESCRIPTION
## PR Type:
Enhancement

___
## PR Description:
- Introduces a new GitHub Actions workflow that tests job failure across different operating systems.
- The workflow is triggered on push events.
- It includes a job named 'build' that fails intentionally to test the failure behavior.
- The 'build' job runs on Ubuntu, Windows, and macOS runners.

___
## PR Main Files Walkthrough:
<details> <summary>files:</summary>

- `.github/workflows/main.yml`: Added a new workflow named 'Test exiting on failure' that is triggered on push events. It includes a 'build' job with a strategy to run on multiple operating systems. The job contains steps to checkout the code, intentionally fail the build, and a step that should not execute due to the prior failure.
</details>
